### PR TITLE
fix github link on menu

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -36,7 +36,7 @@ menu:
         type: search
     - name: GitHub
       weight: 5
-      url: "https://github.com/akitaonrails/akitaonrails-hugo"
+      url: "https://github.com/akitaonrails/akitaonrails.github.io"
       params:
         icon: github
     - name: Twitter


### PR DESCRIPTION
This is the first button I clicked on the new blog, that are redirecting to an private repo maybe.

So, this fix the button to redirect to this public repo