### PR TITLE
fix: email link on about page not displaying as expected

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -17,4 +17,4 @@ I used to travel all around the world to talk at conferences, podcasts, etc. But
 
 I never accepted sponsorships or did any kind of paid content. And I am still not open to be paid to talk things I don't believe in. Do not test me.
 
-If you have important matters to talk to me, you can send an email to my company's [contact email](email://contact@codeminer42.com). I won't reply unless it interests me.
+If you have important matters to talk to me, you can send an email to my company's [contact email](mailto:contact@codeminer42.com). I won't reply unless it interests me.


### PR DESCRIPTION
The email link to email://contact@codeminer42.com was not rendering correctly on the about page. Replaced it with a standard HTML [mailto:](https://developer.mozilla.org/pt-BR/docs/Web/HTML/Reference/Elements/a#href) link to ensure correct behavior.
