### PR TITLE
fix: index xml rendering error

### DIFF
--- a/layouts/_default/list.rss.xml
+++ b/layouts/_default/list.rss.xml
@@ -16,7 +16,7 @@
         <guid isPermaLink="true">{{ .Permalink | absURL }}</guid>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 GMT" }}</pubDate>
         <description>{{ .Summary | html }}</description>
-        <content:encoded><![CDATA[{{ .Content | safeHTML }}]]></content:encoded>
+        
         {{ with .Params.tags }}
           {{- range . }}
             <category>{{ . }}</category>

--- a/layouts/_default/list.rss.xml
+++ b/layouts/_default/list.rss.xml
@@ -16,7 +16,7 @@
         <guid isPermaLink="true">{{ .Permalink | absURL }}</guid>
         <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 GMT" }}</pubDate>
         <description>{{ .Summary | html }}</description>
-        
+        <content:encoded>{{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}</content:encoded>
         {{ with .Params.tags }}
           {{- range . }}
             <category>{{ . }}</category>


### PR DESCRIPTION
There's an error when loading the xml route https://akitaonrails.com/index.xml:
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/9d3a740c-2e4e-4686-8a77-ebdf6a4cf6ef" />

I still investigating this, I know that there's something with <content:encoded><![CDATA[{{ .Content | safeHTML }}]]></content:encoded> because when I remove it on localhost everything works (without content):
<img width="1125" alt="image" src="https://github.com/user-attachments/assets/cbe7f6c5-ed62-4fa1-ad22-deae309e30d5" />

Maybe is something from this [fix_html_entities](https://github.com/akitaonrails/akitaonrails.github.io/blob/master/content/fix_html_entities.rb#L4-L19) @akitaonrails?
