### PR TITLE
Corrige ordenação dos títulos gerados por generate_index.rb.

### DIFF
--- a/scripts/generate_index.rb
+++ b/scripts/generate_index.rb
@@ -26,7 +26,7 @@ Find.find('content/.') do |path|
         front = YAML.safe_load(fm_lines.join)
         if front && front['title'] && front['date']
           date = begin
-            Date.parse(front['date'].to_s)
+            DateTime.parse(front['date'].to_s)
           rescue StandardError
             nil
           end


### PR DESCRIPTION
O problema estava na linha 29, onde o código usava `Date.parse` em vez de `DateTime.parse`. Isso fazia com que apenas a data (ano, mês, dia) fosse preservada, descartando a informação de hora do timestamp. Quando múltiplos posts eram publicados no mesmo dia, todos tinham exatamente a mesma data, tornando a ordenação instável.

Agora com `DateTime.parse`, o timestamp completo é preservado, incluindo hora e timezone, garantindo que posts do mesmo dia sejam ordenados cronologicamente pela hora de publicação, não pelo título.