### PR TITLE
fix: removed analytics secret id for hugo.yaml and configure to using from envs netlify injected

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -9,8 +9,6 @@ outputs:
 services:
   disqus:
     shortname: akitaonrails
-  googleAnalytics:
-    ID: G-XSK3YHXFRY
 
 # import hextra as module
 module:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "public"
-command = "hugo --gc --minify -b ${DEPLOY_PRIME_URL}"
+command = "export HUGO_GOOGLEANALYTICS=$ANALYTICS_KEY && hugo --gc --minify -b ${DEPLOY_PRIME_URL}"
 
 [build.environment]
 HUGO_VERSION = "0.145.0"


### PR DESCRIPTION
Fala Akita blz? 

Cara dando uma olhada rápida achei estranho ter uma chave ali exposta no arquivo de configuração do Hugo, que no caso é a do Google Analytics e bem, eu já configurei no meu usando as `evns` dentro do projeto da Netlify que é meio que "o jeito certo" de deixar isso configurado.

Basta configurar a key no projeto com o mesmo nome que coloquei ai na varíavel e tudo certo.

<img width="874" height="501" alt="Screenshot 2025-10-04 at 17 09 55" src="https://github.com/user-attachments/assets/ec402faa-661d-4678-a50e-97eb5e725bed" />

Já testei no meu blog, então consigo garantir que esse export funciona no step de build.

No mais é isso, obrigado, você me tornou um profissional melhor. ;)