### PR TITLE
Deduplicate search results by article

### DIFF
--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -228,16 +228,20 @@ document.addEventListener("DOMContentLoaded", function () {
       suggest: query.length > 1
     })[0]?.result || [];
 
-    const documents = [];
-    const seen = new Set();
-
+    // Group sections by base URL, keeping the highest-scoring section per article
+    // so the route anchor points to the most relevant section, not an arbitrary one.
+    const bestByPage = new Map();
     for (const result of directResults) {
       const { doc } = result;
       const key = doc.url.split('#')[0];
-      if (seen.has(key)) continue;
-      seen.add(key);
-      documents.push(doc);
+      const score = rankDocument(doc, query);
+      if (!bestByPage.has(key) || score > bestByPage.get(key).score) {
+        bestByPage.set(key, { doc, score });
+      }
     }
+
+    const documents = [...bestByPage.values()].map(({ doc }) => doc);
+    const seen = new Set(bestByPage.keys());
 
     if (documents.length >= limit) {
       return documents;
@@ -409,12 +413,7 @@ document.addEventListener("DOMContentLoaded", function () {
       .sort((a, b) => rankDocument(b, normalizedQuery) - rankDocument(a, normalizedQuery));
 
     const results = [];
-    const seenPages = new Set();
     for (const doc of documents) {
-      const pageKey = doc.url.split('#')[0];
-      if (seenPages.has(pageKey)) {
-        continue;
-      }
       const content = doc.display || doc.content;
       results.push({
         route: doc.url,
@@ -424,7 +423,6 @@ document.addEventListener("DOMContentLoaded", function () {
           content
         }
       });
-      seenPages.add(pageKey);
     }
 
     displayResults(results, query);

--- a/assets/js/flexsearch.js
+++ b/assets/js/flexsearch.js
@@ -233,7 +233,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     for (const result of directResults) {
       const { doc } = result;
-      const key = `${doc.url}@@${doc.display || doc.content}`;
+      const key = doc.url.split('#')[0];
       if (seen.has(key)) continue;
       seen.add(key);
       documents.push(doc);
@@ -244,7 +244,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     for (const doc of fallbackSearch(query, limit * 2)) {
-      const key = `${doc.url}@@${doc.display || doc.content}`;
+      const key = doc.url.split('#')[0];
       if (seen.has(key)) continue;
       seen.add(key);
       documents.push(doc);
@@ -411,16 +411,20 @@ document.addEventListener("DOMContentLoaded", function () {
     const results = [];
     const seenPages = new Set();
     for (const doc of documents) {
+      const pageKey = doc.url.split('#')[0];
+      if (seenPages.has(pageKey)) {
+        continue;
+      }
       const content = doc.display || doc.content;
       results.push({
         route: doc.url,
-        prefix: seenPages.has(doc.url) ? undefined : doc.crumb,
+        prefix: doc.crumb,
         children: {
           title: doc.title,
           content
         }
       });
-      seenPages.add(doc.url);
+      seenPages.add(pageKey);
     }
 
     displayResults(results, query);


### PR DESCRIPTION
## Summary
Fix duplicate search results in the site search menu by deduplicating matches at the article level.
## What changed
- Updated the custom FlexSearch script to collapse repeated fragment hits into a single result per article
- Kept the best matching fragment as the result target
- Preserved fast client-side search behavior without adding extra backend work
## Verification
- Ran `./scripts/dev.sh start`
- Confirmed the site rebuilds successfully with the updated search script
- Checked that the search flow now dedupes by page instead of fragment

### Comparison before/after screenshots:
<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/c7e3835d-5a5b-46d2-8005-164c60695ed2" />

<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/b0bff00c-b02f-490a-925f-bf9c0cfb9f02" />

<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/b3312fcf-e22b-4324-bcc7-fec41a2c8673" />
